### PR TITLE
Configured non-headless to only open a single headed pyboy instance

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ debug:
     archive_states: False
 
 env:
-  headless: True
+  headless: False
   save_final_state: True
   print_rewards: True
   video_dir: video

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,8 @@ wandb:
 debug:
   env:
     headless: False
+    head_ids: #Which environment IDs to display in pyboy (env_id starts at 0 when serial in debug mode)
+      - 0
     stream_wrapper: False
     init_state: "victory_road_5"
     state_dir: pyboy_states
@@ -45,6 +47,10 @@ debug:
 
 env:
   headless: False
+  head_ids: #Which environment IDs to display in pyboy (env_id starts at 1 when multithreaded)
+    - 1
+    - 5
+  disable_ai_actions: False
   save_final_state: True
   print_rewards: True
   video_dir: video

--- a/pokemonred_puffer/environment.py
+++ b/pokemonred_puffer/environment.py
@@ -99,7 +99,6 @@ class RedGymEnv(Env):
         self.print_rewards = env_config.print_rewards
         self.debug = env_config.debug
         self.headless = env_config.headless
-        self.head_id = 0 if self.debug else 1
         self.state_dir = Path(env_config.state_dir)
         self.init_state = env_config.init_state
         self.init_state_name = self.init_state
@@ -124,6 +123,10 @@ class RedGymEnv(Env):
             }
         else:
             raise ValueError("Disable wild enounters must be a boolean or a list of MapIds")
+        if "head_ids" in env_config and isinstance(env_config.head_ids, ListConfig):
+            self.head_ids = env_config.head_ids
+        else:
+            self.head_ids = {0} if self.debug else {1}
 
         self.disable_ai_actions = env_config.disable_ai_actions
         self.auto_teach_cut = env_config.auto_teach_cut
@@ -246,7 +249,7 @@ class RedGymEnv(Env):
             str(env_config.gb_path),
             debug=False,
             no_input=False,
-            window="null" if self.headless or self.env_id != self.head_id else "SDL2",
+            window="null" if self.headless or self.env_id not in self.head_ids else "SDL2",
             log_level="CRITICAL",
             symbols=os.path.join(os.path.dirname(__file__), "pokered.sym"),
         )

--- a/pokemonred_puffer/train.py
+++ b/pokemonred_puffer/train.py
@@ -59,6 +59,7 @@ def load_from_config(config: DictConfig, debug: bool) -> DictConfig:
     debug_config = config.get("debug", OmegaConf.create({})) if debug else OmegaConf.create({})
 
     defaults.merge_with(debug_config)
+    defaults.env.debug = True if debug else False
     return defaults
 
 


### PR DESCRIPTION
Set it up so that headless: False could be used on the main training loop only opening one headed instance of pyboy with the rest remaining headless. Allows an option for following a single sample for general observation minimizing performance impact. Previously, the behaviour when attempting to set headless: False without debug was a crash on launch.