### PR TITLE
Restrict Python version to >=3.10, <3.12 in Pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "wandb",
     "websockets"
 ]
-requires-python = ">= 3.10"
+requires-python = ">= 3.10, < 3.12"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
Following up on the other PR's comments. Python 3.12 causes issues, so restricting it to >=3.10, <3.12 makes sense. 3.11.12 has worked best for me.

Note that the classifiers section in pyproject.toml still mentions python 3.12, so let me know if you want me to remove that too. 